### PR TITLE
Fixed epsilon greedy

### DIFF
--- a/notebook_easy21.ipynb
+++ b/notebook_easy21.ipynb
@@ -425,7 +425,7 @@
     "        action : string, action from epsilon greedy policy\n",
     "        \"\"\"\n",
     "        e = self.N_0/(self.N_0 + self.get_state_counter(state))\n",
-    "        if e < random.uniform(0, 1): \n",
+    "        if e > random.uniform(0, 1): \n",
     "            action = random.choice(self.actions)\n",
     "        else:  \n",
     "            action = self.get_action_w_max_value(state)\n",


### PR DESCRIPTION
Epsilon, as defined here:

```
e = self.N_0/(self.N_0 + self.get_state_counter(state))
        if e > random.uniform(0, 1): 
            action = random.choice(self.actions)
        else:  
            action = self.get_action_w_max_value(state)
```
starts at 1 and decreases to 0. Thus, we should start choosing randomly and converge to greedy as the number of state visits increases. 